### PR TITLE
Add coffee-script to package.json, because 'grunt server' uses it directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"express": "~3.0.0",
 		"grunt": "~0.3.15",
 		"grunt-hustler": "~0.6.1",
-		"grunt-contrib-less": "~0.3.0"
+		"grunt-contrib-less": "~0.3.0",
+		"coffee-script": "~1.3.3"
 	},
 	"engine": "node >= 0.8.1"
 }


### PR DESCRIPTION
I had to add this to my package.json in order to make 'grunt server' work correctly.  I don't typically install coffee-script globally.  This might trip up other people, too.

BTW, thanks for putting this seed project together.  I was looking for something just like this.
