### PR TITLE
And this adds LiveReload.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,3 +1,5 @@
+path = require 'path'
+
 # Build configurations.
 module.exports = (grunt) ->
 	grunt.initConfig
@@ -254,14 +256,35 @@ module.exports = (grunt) ->
 					'clean:temp'
 				]
 
+		# Start an Express server + live reload.
+		express:
+			livereload:
+				options: 
+					port: 3005
+					bases: path.resolve 'dist'
+					debug: true
+					monitor: {}
+					server: path.resolve './server'
+
+		# Restart server when server sources have changed, notify all browsers on change.
+		regarde:
+			dist:
+				files: './dist/**/*'
+				tasks: [
+					'livereload'
+				]
+			server:
+				files: ['server.coffee', 'routes.coffee']
+				tasks: ['express-restart:livereload']
+
 		# Runs a web server at the specified port.
 		# Can optionally watch for changes to the file referenced in the watch setting.
 		# The web server will automatically restart once the changes have been saved.
-		server:
-			app:
-				src: './server.coffee'
-				port: 3005
-				watch: './routes.coffee'
+		#server:
+		#	app:
+		#		src: './server.coffee'
+		#		port: 3005
+		#		watch: './routes.coffee'
 
 		# Runs unit tests using testacular
 		testacular:
@@ -285,6 +308,7 @@ module.exports = (grunt) ->
 	grunt.loadNpmTasks 'grunt-contrib-copy'
 	grunt.loadNpmTasks 'grunt-contrib-imagemin'
 	grunt.loadNpmTasks 'grunt-contrib-less'
+	grunt.loadNpmTasks 'grunt-contrib-livereload'
 	grunt.loadNpmTasks 'grunt-contrib-requirejs'
 	grunt.loadNpmTasks 'grunt-contrib-watch'
 
@@ -297,6 +321,11 @@ module.exports = (grunt) ->
 	# Referenced in package.json.
 	# https://github.com/Dignifiedquire/grunt-testacular
 	grunt.loadNpmTasks 'grunt-testacular'
+
+	# Express server + LiveReload
+	grunt.loadNpmTasks 'grunt-express'
+	# Recommended watcher for LiveReload + Express.
+	grunt.loadNpmTasks 'grunt-regarde'
 
 	# Compiles the app with non-optimized build settings and places the build artifacts in the dist directory.
 	# Enter the following command at the command line to execute this build task:
@@ -346,4 +375,11 @@ module.exports = (grunt) ->
 	grunt.registerTask 'test', [
 		'default'
 		'testacular'
+	]
+
+	# override server task (from grunt-hustler)
+	grunt.registerTask 'server', [
+		'livereload-start'
+		'express'
+		'regarde'
 	]

--- a/package.json
+++ b/package.json
@@ -31,7 +31,11 @@
 		"grunt-contrib-requirejs": "~0.4.0",
 		"grunt-contrib-watch": "~0.3.1",
 		"grunt-hustler": "0.10.0",
-		"grunt-testacular": "~0.3.0"
+		"grunt-testacular": "~0.3.0",
+		"grunt-contrib-livereload": "~0.1.2",
+		"grunt-regarde": "~0.1.1",
+		"grunt-express": "~0.2.0",
+		"socket.io": "~0.9.13"
 	},
 	"engines": {
 		"node": "0.8.x",

--- a/server.coffee
+++ b/server.coffee
@@ -2,9 +2,17 @@ express = require 'express'
 routes = require './routes'
 dir = "#{__dirname}/dist"
 port = process.env.PORT ? process.argv.splice(2)[0] ? 3005
+
+# Create express facility.
 app = express()
+# Create a HTTP server object.
+server = require('http').createServer(app)
+# Create SocketIO binding.
+io = require('socket.io').listen(server)
 
 app.configure ->
+    # use livereload middleware
+    app.use require('grunt-contrib-livereload/lib/utils').livereloadSnippet
 	app.use express.logger 'dev'
 	app.use express.bodyParser()
 	app.use express.methodOverride()
@@ -13,5 +21,7 @@ app.configure ->
 	app.use app.router
 	routes app, dir
 
-app.listen port, ->
-	console.log "started web server at http://localhost:#{port}"
+module.exports = server
+
+# Override: Provide an "use" used by grunt-express.
+module.exports.use = -> app.use.apply app, arguments


### PR DESCRIPTION
#27

Following crazy stuff will be included to archieve this goal:
- grunt-express which handles express directly via a grunt task
- grunt-regarde (some issues with watch + livereload, should be investivated later) see https://github.com/gruntjs/grunt-contrib-watch/issues/45, https://github.com/gruntjs/grunt-contrib-watch/issues/18, https://github.com/gruntjs/grunt-contrib-livereload

Following additional dependencies were (re) added:
- Socket IO which handles live reloading on browser side

In a nutshell:
1. Each change in `dist` will fire an event which can be received by any connected browsers. The connections are made by the live reload middleware plugin.
2. The new task `server` bundles now into server start. The previous task by grunt-hustler is now overloaded.
