### PR TITLE
Just because I'm lazy...

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -150,6 +150,11 @@ module.exports = (grunt) ->
 					debug: true
 					monitor: {}
 					server: path.resolve './server'
+		
+		# Open the Express app in the default browser
+		open:
+			server:
+				url: 'http://localhost:3005'
 
 		# Compresses png files
 		imagemin:
@@ -337,6 +342,10 @@ module.exports = (grunt) ->
 
 	# Recommended watcher for LiveReload + Express.
 	grunt.loadNpmTasks 'grunt-regarde'
+	
+	# Open urls and files from a grunt task
+	# https://github.com/onehealth/grunt-open
+	grunt.loadNpmTasks 'grunt-open'
 
 	# Register grunt tasks supplied by grunt-testacular.
 	# Referenced in package.json.
@@ -357,6 +366,7 @@ module.exports = (grunt) ->
 	grunt.registerTask 'server', [
 		'livereload-start'
 		'express'
+		'open'
 		'regarde'
 	]
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"grunt-contrib-watch": "~0.3.1",
 		"grunt-express": "~0.3.2",
 		"grunt-hustler": "0.11.2",
+		"grunt-open": "~0.2.0",
 		"grunt-regarde": "~0.1.1",
 		"grunt-testacular": "~0.3.0",
 		"socket.io": "~0.9.14"


### PR DESCRIPTION
When you execute 'grunt server', it will now open the app in a browser automatically. No need to get all manual. ;)
