### PR TITLE
Set bower dir to `bower_components`.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
The `copy` task depends on this. Not sure why [Travis](https://travis-ci.org/CaryLandholt/grunt-hustler/builds) did not pick this up. I got

```
Running "less:app" (less) task
>> FileError: 'bootstrap.less' wasn't found in ./.temp/styles/styles.less on line 1, column 1:
>> 1 @import "bootstrap.less";
>> 2
Warning: Error compiling LESS. Use --force to continue.

Aborted due to warnings.
```

when running `grunt`. Anyway, I love this project. Keep up the good work. :+1: 
